### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ The interactive mode launches an IPython session with pycalc loaded and ready to
 go.
 
 
-.. |Development Status| image:: https://pypip.in/status/pycalc/badge.svg
+.. |Development Status| image:: https://img.shields.io/pypi/status/pycalc.svg
    :target: https://pypi.python.org/pypi/pycalc/
 .. |Version| image:: https://img.shields.io/pypi/v/pycalc.svg
    :target: https://pypi.python.org/pypi/pycalc/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pycalc))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pycalc`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.